### PR TITLE
Fix nav active state checks

### DIFF
--- a/_includes/patterns/nav-main-desktop.njk
+++ b/_includes/patterns/nav-main-desktop.njk
@@ -10,14 +10,14 @@
               {% set activeClass = "" %}
               {% set ariaCurrentAttr = "" %}
 
-              {# Check if page.url is defined BEFORE using startsWith #}
-              {% if page.url is defined and item.url === page.url %}
+              {# Ensure page.url is truthy before using startsWith #}
+              {% if page.url and item.url === page.url %}
                 {% set activeClass = "is-active" %}
                 {% set ariaCurrentAttr = "aria-current=\"page\"" %}
-              {# Check if page.url is defined BEFORE using startsWith #}
-              {% elseif page.url is defined and item.url !== "/" and page.url.startsWith(item.url) %}
+              {# Ensure page.url is truthy before using startsWith #}
+              {% elseif page.url and item.url !== "/" and page.url.startsWith(item.url) %}
                 {% set activeClass = "is-active" %}
-                {% set ariaCurrentAttr = "data-current=\"section\"" %} 
+                {% set ariaCurrentAttr = "data-current=\"section\"" %}
               {% endif %}
 
               <a href="{{ item.url }}" class="nav-link {{ activeClass }}" {{ ariaCurrentAttr | safe }}>

--- a/_includes/patterns/nav-main-mobile.njk
+++ b/_includes/patterns/nav-main-mobile.njk
@@ -8,15 +8,15 @@
           {% set activeClass = "" %}
           {% set ariaCurrentAttr = "" %}
 
-          {# CRUCIAL CHANGE: Check if page.url is defined BEFORE using startsWith #}
-          {% if page.url is defined and item.url === page.url %}
-            {% set activeClass = "is-active" %}
-            {% set ariaCurrentAttr = "aria-current=\"page\"" %}
-          {# CRUCIAL CHANGE: Check if page.url is defined BEFORE using startsWith #}
-          {% elif page.url is defined and item.url !== "/" and page.url.startsWith(item.url) %}
-            {% set activeClass = "is-active" %}
-            {% set ariaCurrentAttr = "data-current=\"section\"" %} 
-          {% endif %}
+            {# Ensure page.url is truthy before using startsWith #}
+            {% if page.url and item.url === page.url %}
+              {% set activeClass = "is-active" %}
+              {% set ariaCurrentAttr = "aria-current=\"page\"" %}
+            {# Ensure page.url is truthy before using startsWith #}
+            {% elif page.url and item.url !== "/" and page.url.startsWith(item.url) %}
+              {% set activeClass = "is-active" %}
+              {% set ariaCurrentAttr = "data-current=\"section\"" %}
+            {% endif %}
 
           <a href="{{ item.url }}" class="text-2xl font-medium {{ activeClass }}" {{ ariaCurrentAttr | safe }}>
             {{ item.key }}


### PR DESCRIPTION
## Summary
- guard page.url truthiness when checking active nav states

## Testing
- `npm run dev` *(fails: Missing script)*
- `npm run build` *(fails: 403 Forbidden, network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687632fe7710832b87306dd15c9593bd