### PR TITLE
Fix article generation with pagination

### DIFF
--- a/content/writing/article.njk
+++ b/content/writing/article.njk
@@ -8,9 +8,9 @@
 
 <article>
     {# 'post' is the alias defined in article.11tydata.js pagination #}
-    <h1>{{ post.fields.headline }}</h1> {# Use headline as per your Contentful model #}
-    {% if post.fields.datePublished %}
-        <p class="post-meta">Published: {{ post.fields.datePublished | readableDate("yyyy-MM-dd") }}</p>
+    <h1>{{ post.headline }}</h1>
+    {% if post.datePublished %}
+        <p class="post-meta">Published: {{ post.datePublished | readableDate("yyyy-MM-dd") }}</p>
     {% endif %}
 
     {# Display main image if available #}
@@ -37,7 +37,6 @@
 
     <div class="post-body">
         {# renderRichTextAsHtml is the filter you added in eleventy.config.js #}
-        {{ post.fields.body | renderRichTextAsHtml | safe }}
         {{ post.body | renderRichTextAsHtml }}
     </div>
 </article>

--- a/content/writing/writing.11tydata.js
+++ b/content/writing/writing.11tydata.js
@@ -1,10 +1,25 @@
 // content/writing/writing.11tydata.js
 
 export default {
+  // Generate one page per composeArticle entry
+  pagination: {
+    data: "composeArticle",
+    size: 1,
+    alias: "post",
+  },
   // All files in /content/writing/ to default to this layout
-  layout: "layouts/article.njk", 
+  layout: "layouts/article.njk",
+  // Compute permalink from each article slug
+  eleventyComputed: {
+    permalink: (data) => {
+      if (data.post && data.post.slug) {
+        return `/writing/${data.post.slug}/index.html`;
+      }
+      return false;
+    },
+  },
   // If you want all files in /content/writing/ to have this tag
-  tags: [ 
-    "writing"
-  ]
+  tags: [
+    "writing",
+  ],
 };


### PR DESCRIPTION
## Summary
- generate one article page per `composeArticle` entry
- access article fields directly in template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68762ef872f4832b986820f201bf7200