### PR TITLE
Fix Contentful data fetchers

### DIFF
--- a/_data/getContentfulArticles.js
+++ b/_data/getContentfulArticles.js
@@ -1,21 +1,19 @@
-// _data/articles.js
-
-// 1. Import the client from your helper file
 import client from './helpers/contentfulClient.js';
 
-// 2. Define your asynchronous function that fetches the data
-export default async function() {
+export default async function getContentfulArticles() {
   try {
-    // 3. Use the imported 'client' object to make your query
     const entries = await client.getEntries({
-      content_type: 'article',
-      // ... your query options ...
+      content_type: 'composeArticle',
+      order: '-fields.datePublished',
+      include: 3
     });
 
-    // 4. Return the processed data
-    return entries.items;
+    return entries.items.map(item => ({
+      ...item.fields,
+      sys: item.sys
+    }));
   } catch (error) {
-    console.error('Error fetching articles:', error);
+    console.error('Error fetching composeArticle entries:', error);
     return [];
   }
 }

--- a/_data/getContentfulPages.js
+++ b/_data/getContentfulPages.js
@@ -1,21 +1,19 @@
-// _data/articles.js
-
-// 1. Import the client from your helper file
 import client from './helpers/contentfulClient.js';
 
-// 2. Define your asynchronous function that fetches the data
-export default async function() {
+export default async function getContentfulPages() {
   try {
-    // 3. Use the imported 'client' object to make your query
     const entries = await client.getEntries({
-      content_type: 'page',
-      // ... your query options ...
+      content_type: 'composePage',
+      order: 'fields.pageTitle',
+      include: 3
     });
 
-    // 4. Return the processed data
-    return entries.items;
+    return entries.items.map(item => ({
+      ...item.fields,
+      sys: item.sys
+    }));
   } catch (error) {
-    console.error('Error fetching articles:', error);
+    console.error('Error fetching composePage entries:', error);
     return [];
   }
 }

--- a/_data/getContentfulSiteHomePage.js
+++ b/_data/getContentfulSiteHomePage.js
@@ -1,21 +1,19 @@
-// _data/articles.js
-
-// 1. Import the client from your helper file
 import client from './helpers/contentfulClient.js';
 
-// 2. Define your asynchronous function that fetches the data
-export default async function() {
+export default async function getContentfulSiteHomePage() {
   try {
-    // 3. Use the imported 'client' object to make your query
     const entries = await client.getEntries({
-      content_type: 'page',
-      // ... your query options ...
+      content_type: 'composeSiteHomePage',
+      limit: 1,
+      include: 3
     });
 
-    // 4. Return the processed data
-    return entries.items;
+    return entries.items.map(item => ({
+      ...item.fields,
+      sys: item.sys
+    }));
   } catch (error) {
-    console.error('Error fetching articles:', error);
+    console.error('Error fetching composeSiteHomePage entries:', error);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- implement async data fetchers for Contentful models
- fetch composeArticle, composePage and composeSiteHomePage entries

## Testing
- `node -e "import('./_data/getContentfulArticles.js').then(m=>console.log('ok')).catch(e=>console.error(e))"` *(fails: cannot find package 'contentful')*

------
https://chatgpt.com/codex/tasks/task_e_687ab0aa107c832b906ace287a50d865