### PR TITLE
Add main image helper for articles

### DIFF
--- a/_data/getContentfulArticles.js
+++ b/_data/getContentfulArticles.js
@@ -8,10 +8,39 @@ export default async function getContentfulArticles() {
       include: 3
     });
 
-    return entries.items.map(item => ({
-      ...item.fields,
-      sys: item.sys
-    }));
+    const parseImageWrapper = (wrapper) => {
+      if (!wrapper || !wrapper.fields) {
+        return null;
+      }
+
+      const { imageFile, imageAlternativeText, imageCaption, creatorPhotographer, licenceInformation } = wrapper.fields;
+
+      if (!imageFile?.fields?.file?.url) {
+        return null;
+      }
+
+      const asset = imageFile.fields;
+
+      return {
+        url: `https:${asset.file.url}`,
+        alt: imageAlternativeText || asset.title || '',
+        caption: imageCaption || null,
+        photographer: creatorPhotographer || null,
+        licence: licenceInformation || null,
+        details: asset.file.details,
+      };
+    };
+
+    return entries.items.map(item => {
+      const fields = { ...item.fields };
+
+      fields.mainImage = parseImageWrapper(fields.mainImage);
+
+      return {
+        ...fields,
+        sys: item.sys
+      };
+    });
   } catch (error) {
     console.error('Error fetching composeArticle entries:', error);
     return [];


### PR DESCRIPTION
## Summary
- handle `mainImage` wrapper in `getContentfulArticles`

## Testing
- `npm install` *(fails: Eleventy build requires Contentful credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687aca0feb7c832ba5f46f778c0a42de