### PR TITLE
Add main image parsing for Contentful pages

### DIFF
--- a/_data/getContentfulArticles.js
+++ b/_data/getContentfulArticles.js
@@ -1,4 +1,5 @@
 import client from './helpers/contentfulClient.js';
+import parseImageWrapper from './helpers/parseImageWrapper.js';
 
 export default async function getContentfulArticles() {
   try {
@@ -8,28 +9,6 @@ export default async function getContentfulArticles() {
       include: 3
     });
 
-    const parseImageWrapper = (wrapper) => {
-      if (!wrapper || !wrapper.fields) {
-        return null;
-      }
-
-      const { imageFile, imageAlternativeText, imageCaption, creatorPhotographer, licenceInformation } = wrapper.fields;
-
-      if (!imageFile?.fields?.file?.url) {
-        return null;
-      }
-
-      const asset = imageFile.fields;
-
-      return {
-        url: `https:${asset.file.url}`,
-        alt: imageAlternativeText || asset.title || '',
-        caption: imageCaption || null,
-        photographer: creatorPhotographer || null,
-        licence: licenceInformation || null,
-        details: asset.file.details,
-      };
-    };
 
     return entries.items.map(item => {
       const fields = { ...item.fields };
@@ -46,3 +25,4 @@ export default async function getContentfulArticles() {
     return [];
   }
 }
+

--- a/_data/getContentfulPages.js
+++ b/_data/getContentfulPages.js
@@ -1,4 +1,5 @@
 import client from './helpers/contentfulClient.js';
+import parseImageWrapper from './helpers/parseImageWrapper.js';
 
 export default async function getContentfulPages() {
   try {
@@ -8,12 +9,19 @@ export default async function getContentfulPages() {
       include: 3
     });
 
-    return entries.items.map(item => ({
-      ...item.fields,
-      sys: item.sys
-    }));
+    return entries.items.map(item => {
+      const fields = { ...item.fields };
+
+      fields.mainImage = parseImageWrapper(fields.mainImage);
+
+      return {
+        ...fields,
+        sys: item.sys,
+      };
+    });
   } catch (error) {
     console.error('Error fetching composePage entries:', error);
     return [];
   }
 }
+

--- a/_data/helpers/parseImageWrapper.js
+++ b/_data/helpers/parseImageWrapper.js
@@ -1,0 +1,28 @@
+export default function parseImageWrapper(wrapper) {
+  if (!wrapper || !wrapper.fields) {
+    return null;
+  }
+
+  const {
+    imageFile,
+    imageAlternativeText,
+    imageCaption,
+    creatorPhotographer,
+    licenceInformation,
+  } = wrapper.fields;
+
+  if (!imageFile?.fields?.file?.url) {
+    return null;
+  }
+
+  const asset = imageFile.fields;
+
+  return {
+    url: `https:${asset.file.url}`,
+    alt: imageAlternativeText || asset.title || '',
+    caption: imageCaption || null,
+    photographer: creatorPhotographer || null,
+    licence: licenceInformation || null,
+    details: asset.file.details,
+  };
+}


### PR DESCRIPTION
## Summary
- provide a helper to parse Contentful image wrappers
- reuse helper in article/page data loaders
- expose parsed mainImage field for Page content model

## Testing
- `yes | npm run build --silent` *(fails: Cannot find package '@11ty/eleventy')*

------
https://chatgpt.com/codex/tasks/task_e_687acd7cd960832b93fe97c5b449c2ff