### PR TITLE
Update article layout main image

### DIFF
--- a/_includes/layouts/article.njk
+++ b/_includes/layouts/article.njk
@@ -41,24 +41,16 @@ layout: layouts/base.njk
             </p>
 
             <!-- Main image -->
+            {% if post.mainImage %}
             <div class="overflow-hidden rounded-lg mb-12 max-w-5xl mx-auto">
-                {# Example 2: Using an image path from front matter #}
-                {# Assuming your content file (e.g., src/posts/my-post.md) has: featuredImage: "./src/images/post-hero.jpg" #}
-
-                {% if featuredImage %}
-                    <img src="" alt="{{ featuredImageAltText }}" class="">
-                {% endif %}
-
-
-              {% contentfulImage
-                  post.heroImage,
-                  post.Image.alt,
-                  [1200],
-                  ["webp", "jpeg"],
-                  "(min-width: 1024px) 1024px, 100vw"
-              %}
-
+              <img
+                src="{{ post.mainImage.url }}"
+                alt="{{ post.mainImage.alt }}"
+                width="1024"
+                height="384"
+                class="w-full aspect-[8/3] object-cover">
             </div>
+            {% endif %}
         </section>
 
         <!-- Article Content -->


### PR DESCRIPTION
## Summary
- fetch and display `post.mainImage` in article layout
- optimise the image through Eleventy's transform plugin
- drop unused demo code

## Testing
- `npm run build-nocolor` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_687ae92b74f0832b97dfee646be19cf8