### PR TITLE
Use Contentful publish date and image shortcode

### DIFF
--- a/_includes/layouts/article.njk
+++ b/_includes/layouts/article.njk
@@ -29,9 +29,11 @@ layout: layouts/base.njk
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"></path>
                                 </svg>
                         </span>
+                        {% if post.datePublished %}
                         <span class="article-entry-meta-text">
-                            Published on <a href="#">5 July 2025</a>
+                            Published on <time datetime="{{ post.datePublished | htmlDateString }}">{{ post.datePublished | readableDate }}</time>
                         </span>
+                        {% endif %}
                     </li>
             </div>
           
@@ -43,12 +45,13 @@ layout: layouts/base.njk
             <!-- Main image -->
             {% if post.mainImage %}
             <div class="overflow-hidden rounded-lg mb-12 max-w-5xl mx-auto">
-              <img
-                src="{{ post.mainImage.url }}"
-                alt="{{ post.mainImage.alt }}"
-                width="1024"
-                height="384"
-                class="w-full aspect-[8/3] object-cover">
+              {% contentfulImage
+                post.mainImage,
+                post.mainImage.alt,
+                [400, 800, 1200],
+                ["webp", "jpeg"],
+                "(min-width: 800px) 800px, 100vw"
+              %}
             </div>
             {% endif %}
         </section>


### PR DESCRIPTION
## Summary
- display `datePublished` from Contentful in article layout
- use `contentfulImage` shortcode for article main image

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af0be3ac4832ba7aa9dcf6f6208a3