### PR TITLE
Fix mobile menu toggle

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -58,12 +58,6 @@
     <!-- Mobile Navigation Overlay -->
     <div class="fixed inset-0 z-40 translate-x-full transform bg-white transition-transform duration-300 ease-in-out">
       <div class="flex h-full flex-col items-center justify-center space-y-8 p-8">
-        <button class="absolute top-8 right-8" aria-label="Close menu">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
 
         {% include "patterns/nav-main-mobile.njk" %}
 

--- a/content/article-demo-7.njk
+++ b/content/article-demo-7.njk
@@ -306,12 +306,6 @@ categoryPrimary: Web design
     <!-- Mobile Navigation Overlay -->
     <div class="fixed inset-0 z-40 translate-x-full transform bg-white transition-transform duration-300 ease-in-out pointer-events-none">
       <div class="flex h-full flex-col items-center justify-center space-y-8 p-8">
-        <button class="absolute top-8 right-8" aria-label="Close menu">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
 
         <a href="#" class="text-2xl font-medium">Home</a>
         <a href="#" class="text-2xl font-medium">Writing</a>

--- a/public/assets/scripts/bundle.js
+++ b/public/assets/scripts/bundle.js
@@ -14,16 +14,11 @@
 
       // Mobile menu toggle
       const menuButton = document.querySelector('button[aria-label="Toggle menu"]');
-      const closeButton = document.querySelector('button[aria-label="Close menu"]');
       const mobileNav = document.querySelector('.fixed.inset-0.z-40');
 
-      if (menuButton && closeButton && mobileNav) {
+      if (menuButton && mobileNav) {
         menuButton.addEventListener('click', function() {
-          mobileNav.classList.remove('translate-x-full');
-        });
-
-        closeButton.addEventListener('click', function() {
-          mobileNav.classList.add('translate-x-full');
+          mobileNav.classList.toggle('translate-x-full');
         });
       }
 


### PR DESCRIPTION
## Summary
- remove redundant close button from layout
- toggle nav using hamburger button only
- strip demo close button from article-demo-7

## Testing
- `npm run build` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_687c5e5b1b80832ba87a7b1ead33828f