### PR TITLE
Display article topic tags

### DIFF
--- a/_includes/layouts/article.njk
+++ b/_includes/layouts/article.njk
@@ -18,7 +18,7 @@ layout: layouts/base.njk
                                 </svg>
                         </span>
                         <span class="article-entry-meta-text">
-                            By <a href="/" class="underline decoration-2 underline-offset-3 hover:no-underline">Gareth de Walters</a> on <a href="/" rel="category" class="underline decoration-2 underline-offset-3 hover:no-underline">{{ post.topic }}</a>
+        By <a href="/" class="underline decoration-2 underline-offset-3 hover:no-underline">Gareth de Walters</a> on <a href="/" rel="category" class="underline decoration-2 underline-offset-3 hover:no-underline">{{ post.contentTopicTag.fields.entryTitle }}</a>
                         </span>
                     </li>
 

--- a/content/writing.njk
+++ b/content/writing.njk
@@ -31,7 +31,7 @@
                 <article class="article-card rounded-lg p-6 bg-white shadow-sm hover:shadow-md transition-shadow duration-300">
                     <a href="/writing/{{ article.slug }}/" class="block">
                         <div class="mb-3">
-                            <span class="text-primary text-xs font-medium tracking-wider uppercase"> {{ article.topic }} </span>
+                            <span class="text-primary text-xs font-medium tracking-wider uppercase"> {{ article.contentTopicTag.fields.entryTitle }} </span>
                         </div>
                         <h3 class="mb-3 font-serif text-xl font-medium">{{ article.headline }}</h3>
 


### PR DESCRIPTION
## Summary
- display linked `resourceTopic` tag in writing index and single article layouts

## Testing
- `npm run build-nocolor` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_687c77df075c832bb9de6b3f8004d8da