### PR TITLE
Add debug JSON output to POC and About pages

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -44,7 +44,16 @@ export default function(eleventyConfig) {
 		return (tags || []).filter(tag => ["all", "posts"].indexOf(tag) === -1);
 	});
 
-	eleventyConfig.addFilter("sortAlphabetically", strings =>
-		(strings || []).sort((b, a) => b.localeCompare(a))
-	);
+        eleventyConfig.addFilter("sortAlphabetically", strings =>
+                (strings || []).sort((b, a) => b.localeCompare(a))
+        );
+
+        // Dump object as formatted JSON for debugging
+        eleventyConfig.addFilter("dump", obj => {
+                try {
+                        return JSON.stringify(obj, null, 2);
+                } catch(e) {
+                        return String(obj);
+                }
+        });
 };

--- a/_data/aboutPage.js
+++ b/_data/aboutPage.js
@@ -2,5 +2,7 @@ import getContentfulPages from './getContentfulPages.js';
 
 export default async function () {
   const pages = await getContentfulPages();
-  return pages.find((p) => p.sys && p.sys.id === '6Q96jcdFbNmzlFw6rkjuI3');
+  const page = pages.find((p) => p.sys && p.sys.id === '6Q96jcdFbNmzlFw6rkjuI3');
+  console.debug('About page data:', page);
+  return page;
 }

--- a/_data/pocPage.js
+++ b/_data/pocPage.js
@@ -12,10 +12,14 @@ export default async function () {
     const fields = { ...entry.fields };
     fields.mainImage = parseImageWrapper(fields.mainImage);
 
-    return {
+    const data = {
       ...fields,
       sys: entry.sys,
     };
+
+    console.debug('POC page data:', data);
+
+    return data;
   } catch (err) {
     console.error('Error fetching POC page:', err);
     return {};

--- a/content/about.njk
+++ b/content/about.njk
@@ -16,3 +16,5 @@
     }
 }
 ---
+
+<pre>{{ post | dump | safe }}</pre>

--- a/content/poc.njk
+++ b/content/poc.njk
@@ -8,3 +8,5 @@
   }
 }
 ---
+
+<pre>{{ post | dump | safe }}</pre>


### PR DESCRIPTION
## Summary
- add `dump` filter to aid debugging
- log page data in Contentful data loaders
- dump `post` JSON on POC and About pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ccdc3691c832ba70160ec49dbac07