### PR TITLE
Fix optional chaining usage in Nunjucks template

### DIFF
--- a/_includes/layouts/page.njk
+++ b/_includes/layouts/page.njk
@@ -23,7 +23,7 @@ layout: layouts/base.njk
                   <pre>{{ section | dump | safe }}</pre>
                   <h3>--- End Debugging: Current Section ---</h3>
 
-                  {% set typeId = section.sys?.contentType?.sys?.id %}
+                  {% set typeId = section.sys.contentType.sys.id %}
                   <h3>--- Debugging: typeId ---</h3>
                   <p>typeId: {{ typeId | dump | safe }}</p>
                   <h3>--- End Debugging: typeId ---</h3>


### PR DESCRIPTION
## Summary
- remove unsupported optional chaining `?.` from `page.njk`

## Testing
- `npm run build-nocolor` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_687d4663c618832bb17bc002430b576a