### PR TITLE
Use env variable for site home page ID

### DIFF
--- a/_data/getContentfulSiteHomePage.js
+++ b/_data/getContentfulSiteHomePage.js
@@ -1,8 +1,14 @@
 import client from './helpers/contentfulClient.js';
 
-export default async function getContentfulSiteHomePage(id) {
+export default async function getContentfulSiteHomePage() {
+  const entryId = process.env.SITE_HOME_ENTRY_ID;
+
+  if (!entryId) {
+    throw new Error('SITE_HOME_ENTRY_ID environment variable is required.');
+  }
+
   try {
-    const entry = await client.getEntry('4aiHsUsWbbsmUn9Egjcsk0', { include: 6 });
+    const entry = await client.getEntry(entryId, { include: 6 });
 
     return {
       ...entry.fields,

--- a/_data/siteHomePage.js
+++ b/_data/siteHomePage.js
@@ -1,8 +1,13 @@
 import client from './helpers/contentfulClient.js';
 
 export default async function siteHomePage() {
+  const entryId = process.env.SITE_HOME_ENTRY_ID;
+
+  if (!entryId) {
+    throw new Error('SITE_HOME_ENTRY_ID environment variable is required.');
+  }
+
   try {
-    const entryId = '4aiHsUsWbbsmUn9Egjcsk0';
     const entry = await client.getEntry(entryId, { include: 6 });
 
     return {


### PR DESCRIPTION
## Summary
- load SITE_HOME_ENTRY_ID from env instead of hard-coded ID
- throw an error when SITE_HOME_ENTRY_ID is missing

## Testing
- `npm run build-nocolor`

------
https://chatgpt.com/codex/tasks/task_e_687e8f04624c832bbbe50c14bff5f567