### PR TITLE
Use flatted for cache serialization

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import { stringify } from "flatted";
 
 export default function(eleventyConfig) {
   eleventyConfig.addFilter("readableDate", (dateObj, format, zone) => {
@@ -51,7 +52,7 @@ export default function(eleventyConfig) {
         // Dump object as formatted JSON for debugging
         eleventyConfig.addFilter("dump", obj => {
                 try {
-                        return JSON.stringify(obj, null, 2);
+                        return stringify(obj, null, 2);
                 } catch(e) {
                         return String(obj);
                 }

--- a/_helpers/cache.js
+++ b/_helpers/cache.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { parse, stringify } from 'flatted';
 
 export default async function cachedFetch(key, fetcher, ttlSeconds = 3600) {
   const cacheDir = path.resolve('.cache');
@@ -8,7 +9,7 @@ export default async function cachedFetch(key, fetcher, ttlSeconds = 3600) {
 
   if (fs.existsSync(cacheFile)) {
     try {
-      const { timestamp, payload } = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+      const { timestamp, payload } = parse(fs.readFileSync(cacheFile, 'utf8'));
       if (now - timestamp < ttlSeconds * 1000) {
         return payload;
       }
@@ -21,6 +22,6 @@ export default async function cachedFetch(key, fetcher, ttlSeconds = 3600) {
   if (!fs.existsSync(cacheDir)) {
     fs.mkdirSync(cacheDir, { recursive: true });
   }
-  fs.writeFileSync(cacheFile, JSON.stringify({ timestamp: now, payload }), 'utf8');
+  fs.writeFileSync(cacheFile, stringify({ timestamp: now, payload }), 'utf8');
   return payload;
 }


### PR DESCRIPTION
## Summary
- support circular structures in cached data and debug output
- install flatted dependency

## Testing
- `npm run build` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_6880bd05dd40832bbc0238ea2fce9a18