### PR TITLE
Fix home promo links and image

### DIFF
--- a/_data/getContentfulSiteHomePage.js
+++ b/_data/getContentfulSiteHomePage.js
@@ -1,5 +1,6 @@
 import client from '../_helpers/contentfulClient.js';
 import cachedFetch from '../_helpers/cache.js';
+import parseImageWrapper from '../_helpers/parseImageWrapper.js';
 
 export default async function siteHomePage() {
   const entryId = process.env.SITE_HOME_ENTRY_ID;
@@ -10,8 +11,19 @@ export default async function siteHomePage() {
 
   const fetcher = async () => {
     const entry = await client.getEntry(entryId, { include: 3 });
+    const fields = { ...entry.fields };
+    if (Array.isArray(fields.contentSections)) {
+      fields.contentSections = fields.contentSections.map(section => {
+        const typeId = section.sys?.contentType?.sys?.id;
+        if (typeId === 'patternFeaturePromoPrimary') {
+          const image = parseImageWrapper(section.fields.image);
+          return { ...section, fields: { ...section.fields, image } };
+        }
+        return section;
+      });
+    }
     return {
-      ...entry.fields,
+      ...fields,
       sys: entry.sys
     };
   };

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -19,7 +19,7 @@ layout: layouts/base.njk
               {{ featurePromo.fields.tag.fields.topic }}
             </span>
           </div>
-          <a href="/{{ featurePromo.fields.link.fields.internalContent.fields.slug }}" class="no-underline hover:underline">
+          <a href="/writing/{{ featurePromo.fields.link.fields.internalContent.fields.slug }}/" class="no-underline hover:underline">
             <h1 class="mb-6 font-serif text-4xl leading-tight font-medium md:text-5xl lg:text-6xl">
               {{ featurePromo.fields.desktopHeadline }}
             </h1>
@@ -30,10 +30,10 @@ layout: layouts/base.njk
         </div>
         <div class="animate-scale-in relative">
           <div class="overflow-hidden rounded-lg">
-            <a href="/{{ featurePromo.fields.link.fields.internalContent.fields.slug }}">
+            <a href="/writing/{{ featurePromo.fields.link.fields.internalContent.fields.slug }}/">
               <img
-                src="https:{{ featurePromo.fields.link.fields.internalContent.fields.image.fields.imageFile.fields.file.url }}"
-                alt="{{ featurePromo.fields.link.fields.internalContent.fields.image.fields.imageAlternativeText }}"
+                src="{{ featurePromo.fields.image.url }}"
+                alt="{{ featurePromo.fields.image.alt }}"
                 class="h-[500px] w-full object-cover transition-transform duration-700 ease-in-out hover:scale-105" />
             </a>
           </div>


### PR DESCRIPTION
## Summary
- parse `patternFeaturePromoPrimary` image when loading the home page entry
- update homepage layout to use the parsed image and correct article link path

## Testing
- `npm run build` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_688180305d50832b992f1c88c3ddf9bb