### PR TITLE
Fix mainImage selection in single article fetch

### DIFF
--- a/_data/getContentfulArticleSingle.js
+++ b/_data/getContentfulArticleSingle.js
@@ -28,10 +28,8 @@ export default async function getContentfulArticleSingle() {
     const entry = await client.getEntry(entryId, { include: 3 });
     const fields = { ...entry.fields };
 
-    // ✨ NEW LINE: Apply parseImageWrapper to the mainImage field of the top-level entry ✨
-    if (fields.mainImage) { // Check if mainImage exists before parsing
-      fields.mainImage = parseImageWrapper(fields.mainImage);
-    }
+    const imageEntry = fields.mainImage || fields.image || null;
+    fields.mainImage = parseImageWrapper(imageEntry);
 
     // This 'deck' processing might still be unnecessary if you only want a single article's fields.
     // However, for now, we're leaving it as is, focusing on the mainImage fix.


### PR DESCRIPTION
## Summary
- ensure `_data/getContentfulArticleSingle.js` looks for both `image` and `mainImage`
- always parse whichever exists and set it back on `fields.mainImage`

## Testing
- `CONTENTFUL_SPACE_ID=d CONTENTFUL_ACCESS_TOKEN=d CONTENTFUL_ENVIRONMENT=master npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688425b70998832b8227a8999bb246c3