### PR TITLE
Add SEO parsing helper

### DIFF
--- a/_data/entries/40-entryHomePage.json
+++ b/_data/entries/40-entryHomePage.json
@@ -1,4 +1,3 @@
-// _data/entries/40-entryHomePage.json
 {
   "metadata": {
     "tags": [],

--- a/_data/entries/50-entryHomePageSEO.json
+++ b/_data/entries/50-entryHomePageSEO.json
@@ -1,4 +1,3 @@
-// _data/entries/50-entryHomePageSEO.json
 
 {
   "metadata": {

--- a/_data/getContentfulArticleSingle.js
+++ b/_data/getContentfulArticleSingle.js
@@ -6,6 +6,7 @@
 
 import client from '../_helpers/contentfulClient.js';
 import parseImageWrapper from '../_helpers/parseImageWrapper.js';
+import parseSeo from '../_helpers/parseSeo.js';
 import cachedFetch from '../_helpers/cache.js';
 
 export default async function getContentfulArticleSingle() {
@@ -23,6 +24,9 @@ export default async function getContentfulArticleSingle() {
 
     const imageEntry = fields.mainImage || fields.image || null;
     fields.mainImage = parseImageWrapper(imageEntry);
+    if (fields.seoMetaData) {
+      fields.seo = parseSeo(fields.seoMetaData);
+    }
 
     // This 'deck' processing might still be unnecessary if you only want a single article's fields.
     // However, for now, we're leaving it as is, focusing on the mainImage fix.

--- a/_data/getContentfulArticles.js
+++ b/_data/getContentfulArticles.js
@@ -1,5 +1,6 @@
 import client from '../_helpers/contentfulClient.js';
 import parseImageWrapper from '../_helpers/parseImageWrapper.js';
+import parseSeo from '../_helpers/parseSeo.js';
 import cachedFetch from '../_helpers/cache.js';
 
 export default async function getContentfulArticles() {
@@ -13,6 +14,9 @@ export default async function getContentfulArticles() {
     return entries.items.map(item => {
       const fields = { ...item.fields };
       fields.mainImage = parseImageWrapper(fields.mainImage);
+      if (fields.seoMetaData) {
+        fields.seo = parseSeo(fields.seoMetaData);
+      }
       return {
         ...fields,
         sys: item.sys

--- a/_data/getContentfulPages.js
+++ b/_data/getContentfulPages.js
@@ -1,5 +1,6 @@
 import client from '../_helpers/contentfulClient.js';
 import parseImageWrapper from '../_helpers/parseImageWrapper.js';
+import parseSeo from '../_helpers/parseSeo.js';
 import cachedFetch from '../_helpers/cache.js';
 
 export default async function getContentfulPages() {
@@ -13,6 +14,9 @@ export default async function getContentfulPages() {
     return entries.items.map(item => {
       const fields = { ...item.fields };
       fields.mainImage = parseImageWrapper(fields.mainImage);
+      if (fields.seoMetaData) {
+        fields.seo = parseSeo(fields.seoMetaData);
+      }
       return {
         ...fields,
         sys: item.sys,

--- a/_helpers/parseSeo.js
+++ b/_helpers/parseSeo.js
@@ -1,0 +1,17 @@
+export default function parseSeo(entry) {
+  const fields = entry?.fields || {};
+
+  return {
+    seoTitle: fields.seoTitle || null,
+    metaDescription: fields.metaDescription || null,
+    canonicalUrl: fields.canonicalUrl || null,
+    seoNoIndex: fields.seoNoIndex ?? null,
+    seoNoFollow: fields.seoNoFollow ?? null,
+    openGraphTitle: fields.openGraphTitle || null,
+    openGraphDescription: fields.openGraphDescription || null,
+    openGraphImage: fields.openGraphImage || null,
+    openGraphType: fields.openGraphType || null,
+    openGraphLocale: fields.openGraphLocale || null,
+  };
+}
+

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,8 +4,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gareth de Walters</title>
-    <meta name="description" content="A curated magazine exploring design, culture, and thoughtful living" />
+    {% set seo = post.seo or {} %}
+    {% set seoTitle = seo.seoTitle or metadata.title %}
+    {% set seoDescription = seo.metaDescription or metadata.description %}
+    <title>{{ seoTitle }}</title>
+    <meta name="description" content="{{ seoDescription }}" />
+    <link rel="canonical" href="{{ seo.canonicalUrl or metadata.url }}" />
+    <meta name="robots" content="{{ seo.seoNoIndex ? 'noindex' : 'index' }},{{ seo.seoNoFollow ? 'nofollow' : 'follow' }}" />
+    <meta property="og:title" content="{{ seo.openGraphTitle or seoTitle }}" />
+    <meta property="og:description" content="{{ seo.openGraphDescription or seoDescription }}" />
+    {% if seo.openGraphImage and seo.openGraphImage.fields and seo.openGraphImage.fields.file %}
+    <meta property="og:image" content="https:{{ seo.openGraphImage.fields.file.url }}" />
+    {% endif %}
+    {% if seo.openGraphType %}<meta property="og:type" content="{{ seo.openGraphType }}" />{% endif %}
+    {% if seo.openGraphLocale %}<meta property="og:locale" content="{{ seo.openGraphLocale }}" />{% endif %}
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet" />    
     <link rel="stylesheet" href="/assets/styles/style.css?v={% version %}"/>
   </head>


### PR DESCRIPTION
## Summary
- parse SEO metadata into plain objects
- use parsed SEO info in Contentful data fetchers
- inject SEO values into base layout
- clean example JSON entries so Eleventy can read them

## Testing
- `npm run build` *(fails: Contentful credentials are required)*

------
https://chatgpt.com/codex/tasks/task_e_68860782bfec832bb4642972c5d9f8eb