### PR TITLE
Add helper to fetch pages by slug

### DIFF
--- a/_data/getContentfulPageAbout.js
+++ b/_data/getContentfulPageAbout.js
@@ -1,7 +1,6 @@
-import getContentfulPages from './getContentfulPages.js';
+import { getContentfulPageBySlug } from './getContentfulPageBySlug.js';
 
 export default async function () {
   // See _data/models/contentfulPageEntryAbout.json for a sample entry shape.
-  const pages = await getContentfulPages();
-  return pages.find((p) => p.sys && p.sys.id === '6Q96jcdFbNmzlFw6rkjuI3');
+  return getContentfulPageBySlug('about');
 }

--- a/_data/getContentfulPageBySlug.js
+++ b/_data/getContentfulPageBySlug.js
@@ -1,0 +1,40 @@
+import client from '../_helpers/contentfulClient.js';
+import parseImageWrapper from '../_helpers/parseImageWrapper.js';
+import parseSeo from '../_helpers/parseSeo.js';
+import cachedFetch from '../_helpers/cache.js';
+
+export async function getContentfulPageBySlug(slug) {
+  if (!slug) {
+    return null;
+  }
+
+  const fetcher = async () => {
+    const entries = await client.getEntries({
+      content_type: 'composePage',
+      'fields.slug': slug,
+      include: 3,
+      limit: 1,
+    });
+
+    if (!entries.items.length) {
+      return null;
+    }
+
+    const item = entries.items[0];
+    const fields = { ...item.fields };
+    fields.mainImage = parseImageWrapper(fields.mainImage);
+
+    if (fields.seoMetaData) {
+      fields.seoMetaData = parseSeo(fields.seoMetaData);
+    }
+
+    return { ...fields, sys: item.sys };
+  };
+
+  try {
+    return await cachedFetch(`page_${slug}`, fetcher);
+  } catch (error) {
+    console.error(`Error fetching composePage with slug ${slug}:`, error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- create `getContentfulPageBySlug` utility for fetching a `composePage` by slug
- use the new helper to build the About page data

## Testing
- `npm run build` *(fails: Contentful credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_68888b03f490832ba278e013ad099b5a