### PR TITLE
Fix cache key path sanitation

### DIFF
--- a/_helpers/cache.js
+++ b/_helpers/cache.js
@@ -7,7 +7,8 @@ import { parse, stringify } from 'flatted';
 
 export default async function cachedFetch(key, fetcher, ttlSeconds = 3600) {
   const cacheDir = path.resolve('.cache');
-  const cacheFile = path.join(cacheDir, `${key}.json`);
+  const sanitizedKey = encodeURIComponent(key);
+  const cacheFile = path.join(cacheDir, `${sanitizedKey}.json`);
   const now = Date.now();
 
   if (fs.existsSync(cacheFile)) {


### PR DESCRIPTION
## Summary
- encode cache keys so slugs like `/` don't break caching

## Testing
- `npm run build` *(fails: Contentful credentials (SPACE_ID, ACCESS_TOKEN) are required)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0ebf004832ba94d36eab0a54564